### PR TITLE
Change second dropdown to be labelled as "location"

### DIFF
--- a/R/enabler2_page.R
+++ b/R/enabler2_page.R
@@ -24,7 +24,7 @@ enabler2_tab <- function() {
             ),
             conditionalPanel(condition = "input.select_geography_e2 != 'National'", selectizeInput(
               inputId = "geographic_breakdown_e2",
-              label = "Select a breakdown: ",
+              label = "Select a location: ",
               choices = NULL,
               selected = NULL,
               multiple = FALSE,

--- a/R/outcome1_page.R
+++ b/R/outcome1_page.R
@@ -25,7 +25,7 @@ outcome1_tab <- function() {
             ),
             conditionalPanel(condition = "input.select_geography_o1 != 'National'", selectizeInput(
               inputId = "geographic_breakdown_o1",
-              label = "Select a breakdown: ",
+              label = "Select a location: ",
               choices = NULL,
               selected = NULL,
               multiple = FALSE,

--- a/R/outcome2_page.R
+++ b/R/outcome2_page.R
@@ -26,7 +26,7 @@ outcome2_tab <- function() {
               condition = "input.select_geography_o2 != 'National'",
               selectizeInput(
                 inputId = "geographic_breakdown_o2",
-                label = "Select a breakdown: ",
+                label = "Select a location: ",
                 choices = NULL,
                 selected = NULL,
                 multiple = FALSE,


### PR DESCRIPTION
Second dropdown had text "Select a breakdown:" which has been changed to "Select a location:" for consistency.