### PR TITLE
Eesp/class based gtag trigger

### DIFF
--- a/google-analytics.html
+++ b/google-analytics.html
@@ -27,11 +27,11 @@ The tracking number below MUST be replaced with a unique number, contact the sta
   
 function getActivePage() {
   const activeNavLink = document.querySelector('ul#navlistPanel > li.nav-item > a.nav-link.active');
-  return activeNavLink ? activeNavLink.getAttribute('data-value') : 'Unknown Page';
+  return activeNavLink ? activeNavLink.innerText.trim() : 'Unknown Page';
 }
 
 function getActiveTab() {
-  const activeTabPane = document.querySelector('.tabbable .tab-pane.active.show');
+  const activeTabPane = document.querySelector('.tab-pane.active.show .tab-pane.active');
   return activeTabPane ? activeTabPane.getAttribute('data-value') : 'Unknown Tab';
 }
 
@@ -61,19 +61,16 @@ function getActiveTab() {
   // Adding in custom google analytics tracking for the Accordian selections
   $(document).on('click', '.accordion-button', function(e) {
     const button = e.currentTarget;
-    const collapseId = button.getAttribute('data-bs-target') || button.getAttribute('aria-controls');
-    const collapseEl = collapseId ? document.getElementById(collapseId.replace('#', '')) : null;
     // Only track if accordion is being **opened** (i.e., not already visible)
-    if (collapseEl && !collapseEl.classList.contains('show')) {
+    if ( button.getAttribute('aria-expanded') === 'true') {
       const label = button.innerText.trim();
-      console.log('Active page: ' + getActivePage());
-      console.log('Active domain: ' + getActiveTab());
       gtag('event', 'Accordion Opened', {
         event_category: getActivePage() + ' > ' + getActiveTab(),
         event_label: label
       });
     }
   });
+  
   
   /*  Adding in custom google analytics tracking for the geographic  selections */
   $(document).on('change', 'select', function(e) {

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -91,6 +91,17 @@ Adding in custom google analytics tracking for the domain tabs
     ).getAttribute('data-value')
     });
   });
+
+  $(document).on('click', '.accordion-button', function(e) {
+    gtag(
+      'event', 
+      'Accordion', 
+      {
+        'event_label' : 'Accordion', 
+        'event_category' : e.currentTarget['innerText']
+      }
+    );
+  });
   
 </script>
       

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -24,7 +24,7 @@ The tracking number below MUST be replaced with a unique number, contact the sta
 */
   gtag('config', 'G-Q13T4ENF6C');
   
-
+// This handles tracking the top level choices menu via the active navlistPanel
   $(document).on('click', 'ul#navlistPanel', function(e) {
     gtag('event', 'navlistPanel', {'event_category' : 'navbar click',
     'event_label' : document.querySelector(
@@ -44,53 +44,21 @@ The tracking number below MUST be replaced with a unique number, contact the sta
 Adding in custom google analytics tracking for the domain tabs
 */
 
-  $(document).on('click', 'ul#outcome1_panels', function(e) {
-    gtag('event', 'Outcome1 Domains', {'event_category' : 'O1 Domain clicks',
-    'event_label' : document.querySelector(
-    'ul#outcome1_panels > li.active > a'
-    ).getAttribute('data-value')
-    });
+  $(document).on('click', 'ul.nav-tabs a.active', function(e) {
+    gtag(
+      'event', 
+      'Tab selection', 
+      {
+        'event_category' : 'Tab selection', 
+        'event_label' : e.currentTarget['innerText']
+      }
+    );
   });
   
-  $(document).on('click', 'ul#outcome2_panels', function(e) {
-    gtag('event', 'Outcome2 Domains', {'event_category' : 'O2 Domain clicks',
-    'event_label' : document.querySelector(
-    'ul#outcome2_panels > li.active > a'
-    ).getAttribute('data-value')
-    });
-  });
   
-  $(document).on('click', 'ul#outcome3_panels', function(e) {
-    gtag('event', 'Outcome3 Domains', {'event_category' : 'O3 Domain clicks',
-    'event_label' : document.querySelector(
-    'ul#outcome3_panels > li.active > a'
-    ).getAttribute('data-value')
-    });
-  });
-  
-  $(document).on('click', 'ul#outcome4_panels', function(e) {
-    gtag('event', 'Outcome4 Domains', {'event_category' : 'O4 Domain clicks',
-    'event_label' : document.querySelector(
-    'ul#outcome4_panels > li.active > a'
-    ).getAttribute('data-value')
-    });
-  });
- 
- $(document).on('click', 'ul#enabler2_panels', function(e) {
-    gtag('event', 'Enabler2 Domains', {'event_category' : 'E2 Domain clicks',
-    'event_label' : document.querySelector(
-    'ul#enabler2_panels > li.active > a'
-    ).getAttribute('data-value')
-    });
-  });
-  
-  $(document).on('click', 'ul#enabler3_panels', function(e) {
-    gtag('event', 'Enabler3 Domains', {'event_category' : 'E3 Domain clicks',
-    'event_label' : document.querySelector(
-    'ul#enabler3_panels > li.active > a'
-    ).getAttribute('data-value')
-    });
-  });
+/*
+Adding in custom google analytics tracking for the Accordian selections
+*/
 
   $(document).on('click', '.accordion-button', function(e) {
     console.log(e.currentTarget['innerText']);
@@ -107,6 +75,60 @@ Adding in custom google analytics tracking for the domain tabs
       }
     );
   });
+  
+/*
+  Adding in custom google analytics tracking for the geographic  selections
+
+*/
+
+$(document).on('change', 'select', function(e) {
+      var selectedValue = $(this).val();
+      var selectedId = $(this).attr("id");
+      
+      if (selectedId.startsWith("geographic_breakdown_")) {
+          console.log('Selected value:', selectedValue);
+          console.log('Selected id:', selectedId);
+      
+          gtag(
+            'event', 
+            'Dropdown: Geo-select', 
+          {
+            'event_category' : 'geographic_breakdown', 
+            'event_label' : selectedId,
+            'event_value' : selectedValue
+          });
+      }
+    });
+    
+$(document).on('change', 'select', function(e) {
+      var selectedValue = $(this).val();
+      var selectedId = $(this).attr("id");
+      
+      if (selectedId == "wellbeing_extra_breakdown" || 
+          selectedId == "wellbeing_school_breakdown" || 
+          selectedId == "attainment_extra_breakdown" ||
+          selectedId == "assessment_factors_1" ||
+          selectedId == "assessment_factors_2" ||
+          selectedId == "placement_type_breakdown" ||
+          selectedId == "select_age_group_04" ||
+          selectedId == "leavers_age") {
+            
+          console.log('Selected value:', selectedValue);
+          console.log('Selected id:', selectedId);
+      
+          gtag(
+            'event', 
+            'Dropdown: Non-geographic', 
+          {
+            'event_category' : selectedId, 
+            'event_label' : selectedId,
+            'event_value' : selectedValue
+          }
+    );
+      // You can add more actions here
+  
+      }
+    });
   
 </script>
       

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -24,6 +24,16 @@ The tracking number below MUST be replaced with a unique number, contact the sta
 */
   gtag('config', 'G-Q13T4ENF6C');
   
+  
+function getActivePage() {
+  const activeNavLink = document.querySelector('ul#navlistPanel > li.nav-item > a.nav-link.active');
+  return activeNavLink ? activeNavLink.getAttribute('data-value') : 'Unknown Page';
+}
+function getActiveTab() {
+  const activeTabPane = document.querySelector('.tab-pane.active.show');
+  return activeTabPane ? activeTabPane.getAttribute('data-value') : 'Unknown Tab';
+}
+  
 // This handles tracking the top level choices menu via the active navlistPanel
   $(document).on('click', 'ul#navlistPanel', function(e) {
     gtag('event', 'navlistPanel', {'event_category' : 'navbar click',
@@ -41,7 +51,15 @@ The tracking number below MUST be replaced with a unique number, contact the sta
   });
 
 /* Adding in custom google analytics tracking for the domain tabs */
+  $(document).on('click', 'ul.nav-tabs a', function(e) {
+  gtag('event', 'Tab selection', {
+    'event_category': getActivePage() + ' - Tab selection',
+    'event_label': e.currentTarget.innerText.trim()
+  });
+});
 
+
+/*
   $(document).on('click', 'ul.nav-tabs a.active', function(e) {
     gtag(
       'event', 
@@ -52,11 +70,11 @@ The tracking number below MUST be replaced with a unique number, contact the sta
       }
     );
   });
-  
+  */
   
 /*
 Adding in custom google analytics tracking for the Accordian selections
-*/
+
 
   $(document).on('click', '.accordion-button', function(e) {
     gtag(
@@ -68,6 +86,20 @@ Adding in custom google analytics tracking for the Accordian selections
       }
     );
   });
+*/  
+  $(document).on('click', '.accordion-button', function(e) {
+  const button = e.currentTarget;
+  const collapseId = button.getAttribute('data-bs-target') || button.getAttribute('aria-controls');
+  const collapseEl = collapseId ? document.getElementById(collapseId.replace('#', '')) : null;
+  // Only track if accordion is being **opened** (i.e., not already visible)
+  if (collapseEl && !collapseEl.classList.contains('show')) {
+    const label = button.innerText.trim();
+    gtag('event', 'Accordion Opened', {
+      event_category: getActivePage() + ' > ' + getActiveTab(),
+      event_label: label
+    });
+  }
+});
   
 /*  Adding in custom google analytics tracking for the geographic  selections */
 

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -29,20 +29,13 @@ function getActivePage() {
   const activeNavLink = document.querySelector('ul#navlistPanel > li.nav-item > a.nav-link.active');
   return activeNavLink ? activeNavLink.getAttribute('data-value') : 'Unknown Page';
 }
+
 function getActiveTab() {
-  const activeTabPane = document.querySelector('.tab-pane.active.show');
+  const activeTabPane = document.querySelector('.tabbable .tab-pane.active.show');
   return activeTabPane ? activeTabPane.getAttribute('data-value') : 'Unknown Tab';
 }
-  
-// This handles tracking the top level choices menu via the active navlistPanel
-  $(document).on('click', 'ul#navlistPanel', function(e) {
-    gtag('event', 'navlistPanel', {'event_category' : 'navbar click',
-    'event_label' : document.querySelector(
-      'ul#navlistPanel > li.nav-item > a.nav-link.active'
-    ).getAttribute('data-value')
-    });
-  });
 
+  // record disconnected events
   $(document).on('shiny:disconnected', function(e) {
     gtag('event', 'disconnect', { 
       'event_label' : 'Disconnect',
@@ -50,80 +43,57 @@ function getActiveTab() {
     });
   });
 
-/* Adding in custom google analytics tracking for the domain tabs */
-  $(document).on('click', 'ul.nav-tabs a', function(e) {
-  gtag('event', 'Tab selection', {
-    'event_category': getActivePage() + ' - Tab selection',
-    'event_label': e.currentTarget.innerText.trim()
-  });
-});
-
-
-/*
-  $(document).on('click', 'ul.nav-tabs a.active', function(e) {
-    gtag(
-      'event', 
-      'Tab selection', 
-      {
-        'event_category' : 'Tab selection', 
-        'event_label' : e.currentTarget['innerText']
-      }
-    );
-  });
-  */
-  
-/*
-Adding in custom google analytics tracking for the Accordian selections
-
-
-  $(document).on('click', '.accordion-button', function(e) {
-    gtag(
-      'event', 
-      'Accordion', 
-      {
-        'event_category' : 'Accordion', 
-        'event_label' : e.currentTarget['innerText']
-      }
-    );
-  });
-*/  
-  $(document).on('click', '.accordion-button', function(e) {
-  const button = e.currentTarget;
-  const collapseId = button.getAttribute('data-bs-target') || button.getAttribute('aria-controls');
-  const collapseEl = collapseId ? document.getElementById(collapseId.replace('#', '')) : null;
-  // Only track if accordion is being **opened** (i.e., not already visible)
-  if (collapseEl && !collapseEl.classList.contains('show')) {
-    const label = button.innerText.trim();
-    gtag('event', 'Accordion Opened', {
-      event_category: getActivePage() + ' > ' + getActiveTab(),
-      event_label: label
+  // This handles tracking the top level choices menu via the active navlistPanel
+  $(document).on('click', 'ul#navlistPanel', function(e) {
+    gtag('event', 'navlistPanel', {'event_category' : 'navbar click',
+    'event_label' : getActivePage()
     });
-  }
-});
-  
-/*  Adding in custom google analytics tracking for the geographic  selections */
+  });
 
-$(document).on('change', 'select', function(e) {
+  /* Adding in custom google analytics tracking for the domain tabs */
+  $(document).on('click', 'ul.nav-tabs a', function(e) {
+    gtag('event', 'Domain selection', {
+      'event_category': getActivePage() + ' - Domain selection',
+      'event_label': e.currentTarget.innerText.trim()
+    });
+  });
+
+  // Adding in custom google analytics tracking for the Accordian selections
+  $(document).on('click', '.accordion-button', function(e) {
+    const button = e.currentTarget;
+    const collapseId = button.getAttribute('data-bs-target') || button.getAttribute('aria-controls');
+    const collapseEl = collapseId ? document.getElementById(collapseId.replace('#', '')) : null;
+    // Only track if accordion is being **opened** (i.e., not already visible)
+    if (collapseEl && !collapseEl.classList.contains('show')) {
+      const label = button.innerText.trim();
+      console.log('Active page: ' + getActivePage());
+      console.log('Active domain: ' + getActiveTab());
+      gtag('event', 'Accordion Opened', {
+        event_category: getActivePage() + ' > ' + getActiveTab(),
+        event_label: label
+      });
+    }
+  });
+  
+  /*  Adding in custom google analytics tracking for the geographic  selections */
+  $(document).on('change', 'select', function(e) {
       var selectedValue = $(this).val();
       var selectedId = $(this).attr("id");
       
       if (selectedId.startsWith("geographic_breakdown_")) {
-          console.log('Selected value:', selectedValue);
-          console.log('Selected id:', selectedId);
-      
+          
           gtag(
             'event', 
             'Dropdown: Geo-select', 
           {
-            'event_category' : selectedId, 
+            'event_category' : getActivePage() + ' > ' + getActiveTab(), 
             'event_label' : selectedValue 
           });
       }
     });
 
-/*  Adding in custom google analytics tracking for the Non-geographic  selections */    
-
-$(document).on('change', 'select', function(e) {
+  /*  Adding in custom google analytics tracking for the Non-geographic  selections */    
+  $(document).on('change', 'select', function(e) {
       var selectedValue = $(this).val();
       var selectedId = $(this).attr("id");
       
@@ -135,22 +105,15 @@ $(document).on('change', 'select', function(e) {
           selectedId == "placement_type_breakdown" ||
           selectedId == "select_age_group_o4" ||
           selectedId == "leavers_age") {
-            
-          console.log('Selected value:', selectedValue);
-          console.log('Selected id:', selectedId);
-      
          
           gtag(
             'event', 
             'Dropdown: Non-geographic', 
           {
-            'event_category' : selectedId, 
+            'event_category' : getActivePage() + ' > ' + getActiveTab() + ' > ' + selectedId, 
             'event_label' : selectedValue
-          }
-    );
-      // You can add more actions here
-  
-      }
+          });
+        }
     });
   
 </script>

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -40,9 +40,7 @@ The tracking number below MUST be replaced with a unique number, contact the sta
     });
   });
 
-/*
-Adding in custom google analytics tracking for the domain tabs
-*/
+/* Adding in custom google analytics tracking for the domain tabs */
 
   $(document).on('click', 'ul.nav-tabs a.active', function(e) {
     gtag(
@@ -61,11 +59,6 @@ Adding in custom google analytics tracking for the Accordian selections
 */
 
   $(document).on('click', '.accordion-button', function(e) {
-    console.log(e.currentTarget['innerText']);
-  });
-
-
-  $(document).on('click', '.accordion-button', function(e) {
     gtag(
       'event', 
       'Accordion', 
@@ -76,10 +69,7 @@ Adding in custom google analytics tracking for the Accordian selections
     );
   });
   
-/*
-  Adding in custom google analytics tracking for the geographic  selections
-
-*/
+/*  Adding in custom google analytics tracking for the geographic  selections */
 
 $(document).on('change', 'select', function(e) {
       var selectedValue = $(this).val();
@@ -93,13 +83,14 @@ $(document).on('change', 'select', function(e) {
             'event', 
             'Dropdown: Geo-select', 
           {
-            'event_category' : 'geographic_breakdown', 
-            'event_label' : selectedId,
-            'event_value' : selectedValue
+            'event_category' : selectedId, 
+            'event_label' : selectedValue 
           });
       }
     });
-    
+
+/*  Adding in custom google analytics tracking for the Non-geographic  selections */    
+
 $(document).on('change', 'select', function(e) {
       var selectedValue = $(this).val();
       var selectedId = $(this).attr("id");
@@ -110,19 +101,19 @@ $(document).on('change', 'select', function(e) {
           selectedId == "assessment_factors_1" ||
           selectedId == "assessment_factors_2" ||
           selectedId == "placement_type_breakdown" ||
-          selectedId == "select_age_group_04" ||
+          selectedId == "select_age_group_o4" ||
           selectedId == "leavers_age") {
             
           console.log('Selected value:', selectedValue);
           console.log('Selected id:', selectedId);
       
+         
           gtag(
             'event', 
             'Dropdown: Non-geographic', 
           {
             'event_category' : selectedId, 
-            'event_label' : selectedId,
-            'event_value' : selectedValue
+            'event_label' : selectedValue
           }
     );
       // You can add more actions here

--- a/google-analytics.html
+++ b/google-analytics.html
@@ -93,12 +93,17 @@ Adding in custom google analytics tracking for the domain tabs
   });
 
   $(document).on('click', '.accordion-button', function(e) {
+    console.log(e.currentTarget['innerText']);
+  });
+
+
+  $(document).on('click', '.accordion-button', function(e) {
     gtag(
       'event', 
       'Accordion', 
       {
-        'event_label' : 'Accordion', 
-        'event_category' : e.currentTarget['innerText']
+        'event_category' : 'Accordion', 
+        'event_label' : e.currentTarget['innerText']
       }
     );
   });

--- a/manifest.json
+++ b/manifest.json
@@ -4758,10 +4758,10 @@
       "checksum": "97ac09e80f73e4fa6ff565acc4d89f89"
     },
     ".RData": {
-      "checksum": "933af2a7a6ee99d219ef9da2f37ba287"
+      "checksum": "1474174bd0036ecde388785c2690e5b9"
     },
     ".Rprofile": {
-      "checksum": "07ffa4f9e45a715587d1a7b47aecdbda"
+      "checksum": "f60f1b9fe2efc5e70dd4d52082c94ea7"
     },
     "CODE_OF_CONDUCT.md": {
       "checksum": "7dcf9b0b5bac78fc7d7fe45f8c5102b1"
@@ -4887,7 +4887,7 @@
       "checksum": "1a057fd68a3166ab9d3c7c421e507f53"
     },
     "google-analytics.html": {
-      "checksum": "0291c1ac5a67a868b68332dd166fd450"
+      "checksum": "b4552dfa349c42070503e37d88416290"
     },
     "LICENSE": {
       "checksum": "4ff1ab40947c9cebe66adef6c76f9ba7"

--- a/manifest.json
+++ b/manifest.json
@@ -4748,17 +4748,20 @@
     ".idea/shelf/Uncommitted_changes_before_Update_at_17_04_2025_00_09_[Changes]/shelved.patch": {
       "checksum": "1de07154dd14895247477488fb9df905"
     },
+    ".idea/shelf/Uncommitted_changes_before_Update_at_17_04_2025_00_09__Changes_.xml": {
+      "checksum": "687c9379ea7437ac0e74d98670c43a8b"
+    },
     ".idea/vcs.xml": {
       "checksum": "74d3a64f52848d5e8db631b1685e58c8"
     },
     ".idea/workspace.xml": {
-      "checksum": "6787fcc6ef1f9ef8cf09c447266dd131"
+      "checksum": "97ac09e80f73e4fa6ff565acc4d89f89"
     },
     ".RData": {
       "checksum": "933af2a7a6ee99d219ef9da2f37ba287"
     },
     ".Rprofile": {
-      "checksum": "a2e0f47df2230ec3127c006423850bcc"
+      "checksum": "ea4adc4ce8af500685f487404b5be4d8"
     },
     "CODE_OF_CONDUCT.md": {
       "checksum": "7dcf9b0b5bac78fc7d7fe45f8c5102b1"
@@ -4884,7 +4887,7 @@
       "checksum": "1a057fd68a3166ab9d3c7c421e507f53"
     },
     "google-analytics.html": {
-      "checksum": "f2437bd3366b2deac82b1d3cf9a48c60"
+      "checksum": "0c7f62444a763cd3f6db381d11b2fd9f"
     },
     "LICENSE": {
       "checksum": "4ff1ab40947c9cebe66adef6c76f9ba7"
@@ -4934,6 +4937,9 @@
     "R/plotting.R": {
       "checksum": "add1f7f3f8215e7ac6c0fb9e8cc13df2"
     },
+    "R/qa_sn_datasets.R": {
+      "checksum": "2574a3340554f9e8b88ef9244093ba5a"
+    },
     "R/read_data.R": {
       "checksum": "4a1529e42ed7bbc43286226e6b9fae37"
     },
@@ -4959,7 +4965,7 @@
       "checksum": "0855ac3bdb3afbc31d6cab5e6c00b85d"
     },
     "renv.lock": {
-      "checksum": "969d36564489e320064ad5a661fd1354"
+      "checksum": "881d5a42bc86815c291a2ee2aab033fe"
     },
     "server.R": {
       "checksum": "7d270a5c2c3d95caf128b5200035d999"
@@ -4968,13 +4974,13 @@
       "checksum": "dbdef7689b6abf6badea68c19d5be303"
     },
     "tests/stats_neighbours_testing.R": {
-      "checksum": "915de91f489871c4813947aff1f52d9d"
+      "checksum": "d97776426bfbe915b902e9d58fa56505"
     },
     "tests/testthat.R": {
       "checksum": "12e9b09de5275bdc13bde6ae5a82f8b1"
     },
     "tests/testthat/_snaps/initial_load/CSC_outcomes_and_enablers_initial_load-001.json": {
-      "checksum": "8189dd220774f0b75864744a986f9d36"
+      "checksum": "91a8cbeb759abd7df2cd348fd233b9fe"
     },
     "tests/testthat/_snaps/shinytest2/CSC_outcomes_and_enablers_error_test-001.json": {
       "checksum": "88ecdc72cd844cb0288456b9e196244f"
@@ -5034,7 +5040,7 @@
       "checksum": "3c784298d53f774f4689b7119ab4b4f1"
     },
     "www/cookie-consent.js": {
-      "checksum": "942789aa3ef2153ae6e6236579b53a2e"
+      "checksum": "dd507a9ad0d33b3b3f97546ffc357f23"
     },
     "www/dfe_logo.svg": {
       "checksum": "c23764dae2d73a45a55815d0327be6cb"

--- a/manifest.json
+++ b/manifest.json
@@ -4761,7 +4761,7 @@
       "checksum": "933af2a7a6ee99d219ef9da2f37ba287"
     },
     ".Rprofile": {
-      "checksum": "15658c9ac507d1bce5a3c1a0d4f68f3a"
+      "checksum": "07ffa4f9e45a715587d1a7b47aecdbda"
     },
     "CODE_OF_CONDUCT.md": {
       "checksum": "7dcf9b0b5bac78fc7d7fe45f8c5102b1"
@@ -4887,7 +4887,7 @@
       "checksum": "1a057fd68a3166ab9d3c7c421e507f53"
     },
     "google-analytics.html": {
-      "checksum": "b9db08c0af5b450c0a56eeb2a14c9643"
+      "checksum": "0291c1ac5a67a868b68332dd166fd450"
     },
     "LICENSE": {
       "checksum": "4ff1ab40947c9cebe66adef6c76f9ba7"
@@ -4936,9 +4936,6 @@
     },
     "R/plotting.R": {
       "checksum": "add1f7f3f8215e7ac6c0fb9e8cc13df2"
-    },
-    "R/qa_sn_datasets.R": {
-      "checksum": "1a89c631b98ef8e9cbdb047c62f03934"
     },
     "R/read_data.R": {
       "checksum": "4a1529e42ed7bbc43286226e6b9fae37"

--- a/manifest.json
+++ b/manifest.json
@@ -4761,7 +4761,7 @@
       "checksum": "1474174bd0036ecde388785c2690e5b9"
     },
     ".Rprofile": {
-      "checksum": "f60f1b9fe2efc5e70dd4d52082c94ea7"
+      "checksum": "3acc383f450aa943e30469be2ea10593"
     },
     "CODE_OF_CONDUCT.md": {
       "checksum": "7dcf9b0b5bac78fc7d7fe45f8c5102b1"
@@ -4887,7 +4887,7 @@
       "checksum": "1a057fd68a3166ab9d3c7c421e507f53"
     },
     "google-analytics.html": {
-      "checksum": "b4552dfa349c42070503e37d88416290"
+      "checksum": "c7dc343e37b99f8d66e7f6fd4b724ab4"
     },
     "LICENSE": {
       "checksum": "4ff1ab40947c9cebe66adef6c76f9ba7"

--- a/manifest.json
+++ b/manifest.json
@@ -4761,7 +4761,7 @@
       "checksum": "933af2a7a6ee99d219ef9da2f37ba287"
     },
     ".Rprofile": {
-      "checksum": "ea4adc4ce8af500685f487404b5be4d8"
+      "checksum": "15658c9ac507d1bce5a3c1a0d4f68f3a"
     },
     "CODE_OF_CONDUCT.md": {
       "checksum": "7dcf9b0b5bac78fc7d7fe45f8c5102b1"
@@ -4887,7 +4887,7 @@
       "checksum": "1a057fd68a3166ab9d3c7c421e507f53"
     },
     "google-analytics.html": {
-      "checksum": "0c7f62444a763cd3f6db381d11b2fd9f"
+      "checksum": "b9db08c0af5b450c0a56eeb2a14c9643"
     },
     "LICENSE": {
       "checksum": "4ff1ab40947c9cebe66adef6c76f9ba7"
@@ -4938,7 +4938,7 @@
       "checksum": "add1f7f3f8215e7ac6c0fb9e8cc13df2"
     },
     "R/qa_sn_datasets.R": {
-      "checksum": "2574a3340554f9e8b88ef9244093ba5a"
+      "checksum": "1a89c631b98ef8e9cbdb047c62f03934"
     },
     "R/read_data.R": {
       "checksum": "4a1529e42ed7bbc43286226e6b9fae37"

--- a/renv.lock
+++ b/renv.lock
@@ -1524,7 +1524,7 @@
       "RemoteUsername": "dfe-analytical-services",
       "RemoteRepo": "dfeshiny",
       "RemoteRef": "main",
-      "RemoteSha": "ccaea9d03ca490e4a51320228734a34822d9f8d9",
+      "RemoteSha": "adf5bbfca5481efaaa407b0d6e1115ceb81176ab",
       "RemoteHost": "api.github.com"
     },
     "diffobj": {

--- a/www/cookie-consent.js
+++ b/www/cookie-consent.js
@@ -8,7 +8,7 @@ Shiny.addCustomMessageHandler('cookie-set', function(msg){
   getCookies();
 })
 
-Shiny.addCustomMessageHandler('cookie-remove', function(msg){
+Shiny.addCustomMessageHandler('cookie-clear', function(msg){
   Cookies.remove(msg.name);
   getCookies();
 })
@@ -22,5 +22,3 @@ Shiny.addCustomMessageHandler('analytics-consent', function(msg){
     'analytics_storage': msg.value
   });
 })
-
-


### PR DESCRIPTION
## Pull request overview

Implement various gtag event-based triggers for the dashboard using helpful categorisation to aid reporting.  Key events to be tracked include:

- navListPanel for Page Selections
- Domain selection for tabs chosen (including the page it belongs to)
- Accordion section open (including the page and domain it belongs to)
- Dropdown selections for the geographic breakdown
- Dropdown selections for the other breakdowns (e.g. age_group, assessment_factor, school_type) 

The PR includes generic functions to getActivePage and getActiveTab.

## Pull request checklist

Please check if your PR fulfils the following:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been run locally and are passing (`run_tests_locally()`)
- [ ] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

We currently only track navbar clicks via Google Analytics


## What is the new behaviour?

Trigger additional events for tracking on Google Analytics


